### PR TITLE
docker run wps.gfs fails on syntax error

### DIFF
--- a/wps.run/Dockerfile
+++ b/wps.run/Dockerfile
@@ -19,7 +19,7 @@ RUN ln -s /deps/WRF/main/real.exe .
 
 ENV PATH=$PATH:/deps/libs/bin/
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/deps/libs/lib
-CMD ["sh","run.sh"]
+CMD ["bash","run.sh"]
 
 ADD namelist-prepare namelist-prepare
 ADD needs-constants needs-constants


### PR DESCRIPTION
Trying to do a `docker run wps.gfs` using the default CMD which is defined in `wps.run/Dockerfile` as `CMD ["sh","run.sh"]` 
The run fails with this error:
```bash
run.sh: 79: run.sh: Syntax error: "(" unexpected
```
The file `run.sh` is using in some places a bash syntax causing issues if it is run using `sh`.
So changing `sh`to `bash`as the shell to use in CMD defined in the Docker.